### PR TITLE
Introduce N+1 issue as example

### DIFF
--- a/src/data/comments.ts
+++ b/src/data/comments.ts
@@ -7,11 +7,12 @@ export const getAllComments = ({ take }: { take: number }) => (
 export const getPostComments = ({
   postId, take
 }: { postId: string, take: number }) => (
-  dbClient.post.findUnique({
+  dbClient.comment.findMany({
     where: {
-      id: postId
-    }
-  }).comments({ take })
+      postId
+    },
+    take
+  })
 )
 
 export const getCommentAuthor = ({ commentId }: { commentId: string }) => (

--- a/src/data/config.ts
+++ b/src/data/config.ts
@@ -3,3 +3,18 @@ import { PrismaClient } from '@prisma/client'
 export const dbClient = new PrismaClient({
   log: ['query', 'info', 'warn', 'error']
 })
+
+/**
+ * Logs the time taken for a Prisma Query to run
+ */
+dbClient.$use(async (params, next) => {
+  const before = Date.now()
+
+  const result = await next(params)
+
+  const after = Date.now()
+
+  console.log(`⏰ Query ${params.model}.${params.action} took ${after - before}ms`)
+
+  return result
+})

--- a/src/data/posts.ts
+++ b/src/data/posts.ts
@@ -7,11 +7,12 @@ export const getAllPosts = ({ take }: { take: number }) => (
 export const getUserPosts = ({
   userId, take
 }: { userId: string, take: number }) => (
-  dbClient.user.findUnique({
+  dbClient.post.findMany({
     where: {
-      id: userId
-    }
-  }).posts({ take })
+      authorId: userId
+    },
+    take
+  })
 )
 
 export const getPostAuthor = ({ postId }: { postId: string }) => (


### PR DESCRIPTION
## Summary
The current version of `main` branch already solves N+1 issue with the queries, but this PR is just an example of what would raise issues

### N+1 definition
> The n+1 problem occurs when you loop through the results of a query and perform one additional query per result, resulting in n number of queries plus the original (n+1). This is a common problem with ORMs, particularly in combination with GraphQL, because it is not always immediately obvious that your code is generating inefficient queries.

[Reference](
https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance#solving-n1-in-graphql-with-findunique-and-prismas-dataloader)

### Prisma as a solution
> The Prisma Client dataloader automatically batches findUnique queries that ✔ occur in the same tick and ✔ have the same where and include parameters.

[Reference](https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance#solving-n1-in-graphql-with-findunique-and-prismas-dataloader)
Besides Prisma, N+1 issue can also be solved by manually implementing batching using the [DataLoader](https://github.com/graphql/dataloader) library

### N+1 issue example based on logs

The following GraphQL query runs the `users` resolver to get all users + the `posts` resolver once per user to get each user's posts + the `comments` resolver per post to get each post's comments (N+1)
```graphql
users {
    id
    name
    posts {
      title
      comments {
        text
      }
    }
  }
```

<img width="400" alt="Screenshot 2022-01-17 at 14 03 25" src="https://user-images.githubusercontent.com/48022589/149774100-31fcb643-8133-4cba-b2aa-cee2bdeea0d9.png">

The `users` query uses user.findMany(..) to return all users:
```js
export const getAllUsers = ({ take }: { take: number }) => (
  dbClient.user.findMany({ take })
)
```
This results in a single SQL query:
```bash
prisma:query SELECT "public"."users"."id", "public"."users"."name", "public"."users"."email", "public"."users"."createdAt" FROM "public"."users" WHERE 1=1 OFFSET $1
⏰ Query User.findMany took 16ms
```
However, the resolver function for `posts` is then invoked once per user - This results in a `findMany` query per user rather than a single `findMany` to return all posts by all users

### Logs by using `findUnique`

<img width="400" alt="Screenshot 2022-01-17 at 14 09 34" src="https://user-images.githubusercontent.com/48022589/149774917-c2f8428b-9921-4463-a0e1-79212020091f.png">
